### PR TITLE
Add exclamation mark to method_name

### DIFF
--- a/lib/active_elastic_job/message_verifier.rb
+++ b/lib/active_elastic_job/message_verifier.rb
@@ -13,7 +13,7 @@ module ActiveElasticJob
       @secret = secret
     end
 
-    def verify(message, digest)
+    def verify!(message, digest)
       if message.nil? || message.blank? || digest.nil? || digest.blank?
         raise InvalidDigest
       end

--- a/lib/active_elastic_job/rack/sqs_message_consumer.rb
+++ b/lib/active_elastic_job/rack/sqs_message_consumer.rb
@@ -23,7 +23,7 @@ module ActiveElasticJob
         request = ActionDispatch::Request.new env
         if aws_sqsd?(request)
           begin
-            verify(request)
+            verify!(request)
             job = JSON.load(request.body)
             ActiveJob::Base.execute(job)
           rescue ActiveElasticJob::MessageVerifier::InvalidDigest => e
@@ -38,11 +38,11 @@ module ActiveElasticJob
 
       private
 
-      def verify(request)
+      def verify!(request)
         secret_key_base = Rails.application.secrets[:secret_key_base]
         @verifier ||= ActiveElasticJob::MessageVerifier.new(secret_key_base)
         digest = request.headers['HTTP_X_AWS_SQSD_ATTR_MESSAGE_DIGEST']
-        @verifier.verify(request.body.string, digest)
+        @verifier.verify!(request.body.string, digest)
       end
 
       def aws_sqsd?(request)

--- a/spec/active_elastic_job/message_verifier_spec.rb
+++ b/spec/active_elastic_job/message_verifier_spec.rb
@@ -9,7 +9,7 @@ describe ActiveElasticJob::MessageVerifier do
   context "when digest is correct" do
     let(:digest) { verifier.generate_digest(message) }
     it "verfies" do
-      expect(verifier.verify(message, digest)).to be_truthy
+      expect(verifier.verify!(message, digest)).to be_truthy
     end
   end
 
@@ -17,7 +17,7 @@ describe ActiveElasticJob::MessageVerifier do
     let(:digest) { 'sth incorrect' }
 
     it "does not verify" do
-      expect { verifier.verify(message, digest) }.to raise_error(ActiveElasticJob::MessageVerifier::InvalidDigest)
+      expect { verifier.verify!(message, digest) }.to raise_error(ActiveElasticJob::MessageVerifier::InvalidDigest)
     end
   end
 end


### PR DESCRIPTION
It becomes more clear that this method throws an error.