### PR TITLE
Created instance method of enqueue

### DIFF
--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -82,6 +82,10 @@ module ActiveJob
         end
       end
 
+      def enqueue(job) #:nodoc:
+        ActiveElasticJobAdapter.enqueue job
+      end
+
       class << self
         def enqueue(job) #:nodoc:
           enqueue_at(job, Time.now)


### PR DESCRIPTION
Looking at all the adapters shipping with Rails 5, to include the test adapter,
the enqueue method is an instance method. This added instance method is a proxy
to the class method.