### PR TITLE
Suppress "No such file or directory" output

### DIFF
--- a/lib/active_elastic_job/rack/sqs_message_consumer.rb
+++ b/lib/active_elastic_job/rack/sqs_message_consumer.rb
@@ -19,7 +19,7 @@ module ActiveElasticJob
       CONTENT_TYPE = 'application/json'.freeze
       CONTENT_TYPE_HEADER_NAME = 'Content-Type'.freeze
       OK_RESPONSE_CODE = '200'.freeze
-      INSIDE_DOCKER_CONTAINER = `cat /proc/1/cgroup` =~ /docker/
+      INSIDE_DOCKER_CONTAINER = `[ -f /proc/1/cgroup ] && cat /proc/1/cgroup` =~ /docker/
       DOCKER_HOST_IP = "172.17.0.1".freeze
 
       def initialize(app) #:nodoc:


### PR DESCRIPTION
The full message is “cat: /proc/1/cgroup: No such file or directory”. Note that I have only tested this on the latest OS X and Elastic Beanstalk.