### PR TITLE
Fix compile problem in dev with Ruby 2.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,6 @@ GEM
       activesupport (>= 4.1.0)
     i18n (0.7.0)
     jmespath (1.3.0)
-    json (1.8.3)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -111,8 +110,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (11.3.0)
-    rdoc (4.2.1)
-      json (~> 1.4)
+    rdoc (5.0.0)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -160,4 +158,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.11.2
+   1.14.3


### PR DESCRIPTION
"json" gem version 1.8.3 won't compile under the latest version of Ruby. This prevented `bundle install` from completing in this project. This commit lets rdoc upgrade to 5.0, which does not depend on json.

Note: this isn't preventing gem installs of active-elastic-job - it only affects people who clone and try to `bundle install` with MRB 2.4.