### PR TITLE
Fix issue #72

### DIFF
--- a/lib/active_elastic_job/railtie.rb
+++ b/lib/active_elastic_job/railtie.rb
@@ -1,7 +1,7 @@
 module ActiveElasticJob
   class Railtie < Rails::Railtie
     config.active_elastic_job = ActiveSupport::OrderedOptions.new
-    config.active_elastic_job.process_jobs = ENV['PROCESS_ACTIVE_ELASTIC_JOBS'] == 'true'
+    config.active_elastic_job.process_jobs = ENV['PROCESS_ACTIVE_ELASTIC_JOBS'].downcase == 'true'
     config.active_elastic_job.aws_credentials = lambda { Aws::InstanceProfileCredentials.new }
     config.active_elastic_job.periodic_tasks_route = '/periodic_tasks'.freeze
 


### PR DESCRIPTION
#72 This PR fixes an issue where `PROCESS_ACTIVE_ELASTIC_JOBS` would require it to be `true` where as `TRUE`, `True`, etc would be invalid. `PROCESS_ACTIVE_ELASTIC_JOBS` is now downcased and then checked with `true`.