### PR TITLE
Update aws-sdk to v3

### DIFF
--- a/active-elastic-job.gemspec
+++ b/active-elastic-job.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk-sqs', '~> 1'
   spec.add_dependency 'rails', '>= 4.2'
 end

--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -125,7 +125,7 @@ module ActiveJob
         private
 
         def aws_client_verifies_md5_digests?
-          Gem::Version.new(Aws::VERSION) >= Gem::Version.new('2.2.19'.freeze)
+          Gem::Version.new(Aws::CORE_GEM_VERSION) >= Gem::Version.new('2.2.19'.freeze)
         end
 
         def build_message(queue_name, serialized_job, timestamp)

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,5 +1,5 @@
 require 'fileutils'
-require 'aws-sdk'
+require 'aws-sdk-sqs'
 require 'open-uri'
 require 'active_job'
 require 'active_job/queue_adapters'


### PR DESCRIPTION
I had version conflicts when using this gem with the latest aws-sdk so I was wondering if youre up for bumping the version.

> Version 3 modularizes the monolithic SDK into service specific gems. Aside from gem packaging differences, version 3 interfaces are backwards compatible with version 2.
https://github.com/aws/aws-sdk-ruby#upgrading-guide

**Note** I had trouble running the tests locally, so im hoping travis would catch any problems this PR might cause