### PR TITLE
RangeError is too general for the 15 minute max delay

### DIFF
--- a/spec/active_job/queue_adapters/active_elastic_job_adapter_spec.rb
+++ b/spec/active_job/queue_adapters/active_elastic_job_adapter_spec.rb
@@ -93,8 +93,9 @@ describe ActiveJob::QueueAdapters::ActiveElasticJobAdapter do
     context "when scheduled timestamp exceeds 15 minutes" do
       let(:delay) { 16.minutes }
 
-      it "raises a RangeError" do
-        expect { adapter.enqueue_at(job, timestamp) }.to raise_error(RangeError)
+      it "raises a DelayTooLong" do
+        expect { adapter.enqueue_at(job, timestamp) }
+          .to raise_error(ActiveJob::QueueAdapters::ActiveElasticJobAdapter::DelayTooLong)
       end
     end
   end


### PR DESCRIPTION
IMO `RangeError` is to general for this exception. If this raises it would be so nice to rescue a specific error instead of any other issues that could result in a `RangeError`.

For backwards compatibility, the error class I've defined `DelayTooLong` extends `RangeError` so if a user wants to rescue on `RangeError` anyway, they can.