### PR TITLE
Allow full configuration of how SQS client connects

### DIFF
--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -184,7 +184,7 @@ module ActiveJob
         end
 
         def aws_region
-          config.aws_region
+          aws_sqs_client.config.region
         end
 
         def config

--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -172,9 +172,17 @@ module ActiveJob
         end
 
         def aws_sqs_client
-          @aws_sqs_client ||= Aws::SQS::Client.new(credentials: aws_sqs_client_credentials )
+          @aws_sqs_client ||= Aws::SQS::Client.new(aws_sqs_client_config)
         end
 
+        def aws_sqs_client_config
+          aws_connection_config = config.aws_connection_config || {}
+          aws_connection_config.merge(
+            credentials: aws_sqs_client_credentials
+          )
+        end
+
+        # Returns an Aws::Credentials instance
         def aws_sqs_client_credentials
           @aws_credentials ||= if config.aws_credentials.kind_of?(Proc)
                                  config.aws_credentials.call


### PR DESCRIPTION
Simply setting `aws_connection_config` to a hash with the relevant config.

Example of use:

``` ruby
config.active_elastic_job.aws_connection_config = {
  endpoint: 'http://localhost:4576',
  verify_checksums: false
}
```

This switches the endpoint to connect to a local service, could be a [localstack](https://github.com/localstack/localstack) used for development.

Any thoughts?