### PR TITLE
Upgrade to AWS SDK v3

### DIFF
--- a/active-elastic-job.gemspec
+++ b/active-elastic-job.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'aws-sdk', '~> 2'
+  spec.add_dependency 'aws-sdk', '~> 3'
   spec.add_dependency 'rails', '>= 4.2'
 end

--- a/lib/active_elastic_job.rb
+++ b/lib/active_elastic_job.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk-core'
+require 'aws-sdk'
 require 'active_elastic_job/version'
 require 'active_elastic_job/md5_message_digest_calculation'
 require 'active_job/queue_adapters/active_elastic_job_adapter'

--- a/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
+++ b/lib/active_job/queue_adapters/active_elastic_job_adapter.rb
@@ -125,7 +125,7 @@ module ActiveJob
         private
 
         def aws_client_verifies_md5_digests?
-          Gem::Version.new(Aws::VERSION) >= Gem::Version.new('2.2.19'.freeze)
+          Gem::Version.new(Aws::CORE_GEM_VERSION) >= Gem::Version.new('2.2.19'.freeze)
         end
 
         def build_message(queue_name, serialized_job, timestamp)


### PR DESCRIPTION
This is the minimal amount of effort required according to https://aws.amazon.com/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/