### PR TITLE
Fix logic for detection of Docker environments in a multi-container enviroment

### DIFF
--- a/lib/active_elastic_job/rack/sqs_message_consumer.rb
+++ b/lib/active_elastic_job/rack/sqs_message_consumer.rb
@@ -122,7 +122,7 @@ module ActiveElasticJob
       end
 
       def app_runs_in_docker_container?
-        @app_in_docker_container ||= `[ -f /proc/1/cgroup ] && cat /proc/1/cgroup` =~ /docker/
+        @app_in_docker_container ||= `[ -f /proc/1/cgroup ] && cat /proc/1/cgroup` =~ /(ecs|docker)/
       end
     end
   end

--- a/lib/active_elastic_job/rack/sqs_message_consumer.rb
+++ b/lib/active_elastic_job/rack/sqs_message_consumer.rb
@@ -25,7 +25,7 @@ module ActiveElasticJob
         { 'Content-Type'.freeze => 'text/plain'.freeze },
         [ 'Request forbidden!'.freeze ]
       ]
-      DOCKER_HOST_IP = '172.17.0.1'.freeze
+      DOCKER_HOST_IP = /172.17.0.\d+/.freeze
 
       def initialize(app) #:nodoc:
         @app = app
@@ -118,7 +118,7 @@ module ActiveElasticJob
       end
 
       def sent_from_docker_host?(request)
-        app_runs_in_docker_container? && request.remote_ip == DOCKER_HOST_IP
+        app_runs_in_docker_container? && request.remote_ip =~ DOCKER_HOST_IP
       end
 
       def app_runs_in_docker_container?


### PR DESCRIPTION
This includes the fix from https://github.com/tawan/active-elastic-job/pull/107 for the detection of whether the app runs in a Docker container or not (to support execution within a multi-container Elastic Beanstalk environment) and also a relaxing of the match for Docker host IPs, again to support multi-container environments.

## References

- https://github.com/tawan/active-elastic-job/pull/107
- https://github.com/tawan/active-elastic-job/issues/94
- https://github.com/tawan/active-elastic-job/issues/104