### PR TITLE
Expand Docker detection to include Docker Compose bridge networking

### DIFF
--- a/lib/active_elastic_job/rack/sqs_message_consumer.rb
+++ b/lib/active_elastic_job/rack/sqs_message_consumer.rb
@@ -25,7 +25,10 @@ module ActiveElasticJob
         { 'Content-Type'.freeze => 'text/plain'.freeze },
         [ 'Request forbidden!'.freeze ]
       ]
-      DOCKER_HOST_IP = /172.17.0.\d+/.freeze
+
+      # 172.17.0.x is the default for Docker
+      # 172.18.0.x is the default for the bridge network of Docker Compose
+      DOCKER_HOST_IP = /172.1(7|8).0.\d+/.freeze
 
       def initialize(app) #:nodoc:
         @app = app


### PR DESCRIPTION
As the Multicontainer Docker platform [is due to be retired in June 2022](https://docs.aws.amazon.com/elasticbeanstalk/latest/platforms/platforms-retiring.html#platforms-retiring.mcdocker) we are moving to the new Docker runtime which is based on Amazon Linux 2 and supports the use of Docker Compose.

In #111 the Docker IP check was expanded to work under the multicontainer runtime (run via ECS) as well as the single container runtime. This PR now further expands the check to allow for a setup based on Docker Compose, by allowing requests from `172.18.0.x` as well as `172.17.0.x`.