### PR TITLE
Optimize middleware for Ruby's object shapes

### DIFF
--- a/lib/active_elastic_job/railtie.rb
+++ b/lib/active_elastic_job/railtie.rb
@@ -2,7 +2,7 @@ module ActiveElasticJob
   class Railtie < Rails::Railtie
     config.active_elastic_job = ActiveSupport::OrderedOptions.new
     process_active_elastic_jobs = ENV['PROCESS_ACTIVE_ELASTIC_JOBS']
-    config.active_elastic_job.process_jobs = !process_active_elastic_jobs.nil? && process_active_elastic_jobs.downcase == 'true'
+    config.active_elastic_job.process_jobs = process_active_elastic_jobs&.downcase == 'true'
     config.active_elastic_job.aws_credentials = lambda { Aws::InstanceProfileCredentials.new }
     config.active_elastic_job.aws_region = ENV['AWS_REGION']
     config.active_elastic_job.periodic_tasks_route = '/periodic_tasks'.freeze

--- a/spec/active_elastic_job/rack/sqs_message_consumer_spec.rb
+++ b/spec/active_elastic_job/rack/sqs_message_consumer_spec.rb
@@ -142,7 +142,7 @@ describe ActiveElasticJob::Rack::SqsMessageConsumer do
       let(:origin_attribute) { "AEJ" }
 
       before do
-        expect(sqs_message_consumer).to receive(:app_runs_in_docker_container?) { true }
+        expect(sqs_message_consumer).to receive(:in_docker_container?) { true }
       end
 
       context 'in a single container environment' do


### PR DESCRIPTION
Ruby 3.2 introduced the concept of [object shapes](https://poddarayush.com/posts/object-shapes-improve-ruby-code-performance/) and initializing all of the ivars up front in the initializer helps take better advantage of them.

In addition to that, these changes also stop running the Docker check on every call to the method and cache that result.