### PR TITLE
Add rails 7.2 support, add more matrix testing to github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,19 +19,27 @@ jobs:
           - 4566:4566
     strategy:
       matrix:
-        gemfile: 
+        gemfile:
           - rails52
           - rails60
           - rails61
           - rails70
-        ruby: 
+          - rails71
+          - rails72
+        ruby:
           - "2.7"
           - "3.0"
+          - "3.2"
+          - "3.3"
         except_deploy:
           - "true"
         exclude:
           - gemfile: rails52
             ruby: "3.0"
+          - gemfile: rails52
+            ruby: "3.2"
+          - gemfile: rails52
+            ruby: "3.3"
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
@@ -41,7 +49,7 @@ jobs:
       AWS_REGION: us-east-1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -66,9 +74,9 @@ jobs:
           - 4566:4566
     strategy:
       matrix:
-        gemfile: 
+        gemfile:
           - rails70
-        ruby: 
+        ruby:
           - "3.0"
         except_deploy:
           - "false"
@@ -93,7 +101,7 @@ jobs:
         uses: byu-oit/github-action-disallow-concurrent-runs@v2
         with:
           token: ${{ github.token }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1.62.0
         with:
@@ -106,4 +114,3 @@ jobs:
           sudo pip install awsebcli --ignore-installed
       - name: Run tests
         run: bundle exec rspec spec
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,10 @@ jobs:
             ruby: "3.2"
           - gemfile: rails52
             ruby: "3.3"
+          - gemfile: rails72
+            ruby: "2.7"
+          - gemfile: rails72
+            ruby: "3.0"
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ aws_policy.json
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+gemfiles/*.gemfile.lock

--- a/README.md
+++ b/README.md
@@ -243,13 +243,14 @@ When you have found the requests, check their response codes which give a clue o
 
 Whether you catch a bug, have a question or a suggestion for improvement, I sincerely appreciate any feedback. Please feel free to [create an issue](https://github.com/active-elastic-job/active-elastic-job/issues/new) and I will follow up as soon as possible.
 
-
 ## Contribute
 
-Running the complete test suite requires to launch elastic beanstalk environments. Travis builds triggered by a pull request will launch the needed elastic beanstalk environments and subsequently run the complete test suite. You can run all specs that do not depend on running elasitic beanstalk environments by setting an environment variable:
- ```bash
+Running the complete test suite requires to launch elastic beanstalk environments. GitHub Actions builds triggered by a pull request will launch the needed elastic beanstalk environments and subsequently run the complete test suite. You can run all specs that do not depend on running elasitic beanstalk environments by setting an environment variable:
+
+```bash
 EXCEPT_DEPLOYED=true bundle exec rspec spec
 ```
+
 Feel free to issue a pull request, if this subset of specs passes.
 
 ### Development environment with Docker

--- a/gemfiles/rails71.gemfile
+++ b/gemfiles/rails71.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'rails', '~> 7.1', '>= 7.1.4.1', '< 7.2'

--- a/gemfiles/rails72.gemfile
+++ b/gemfiles/rails72.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'rails', '~> 7.2', '>= 7.2.1.1'

--- a/lib/active_elastic_job/rack/sqs_message_consumer.rb
+++ b/lib/active_elastic_job/rack/sqs_message_consumer.rb
@@ -13,7 +13,7 @@ module ActiveElasticJob
     # (2) the processed SQS message was queued by this gem representing an active job.
     # In this case it verifies the digest which is sent along with a legit SQS
     # message, and passed as an HTTP header in the resulting request.
-    # The digest is based on Rails' +secrets.secret_key_base+.
+    # The digest is based on +config.active_elastic_job.secret_key_base+.
     # Therefore, the application running in the web environment, which generates
     # the digest, and the application running in the worker
     # environment, which verifies the digest, have to use the *same*

--- a/lib/active_elastic_job/railtie.rb
+++ b/lib/active_elastic_job/railtie.rb
@@ -9,7 +9,7 @@ module ActiveElasticJob
 
     initializer "active_elastic_job.insert_middleware" do |app|
       if app.config.active_elastic_job.secret_key_base.blank?
-        app.config.active_elastic_job.secret_key_base = ENV["SECRET_KEY_BASE"] || app.credentials.secret_key_base || app.secrets.secret_key_base
+        app.config.active_elastic_job.secret_key_base = ENV["SECRET_KEY_BASE"] || app.credentials.secret_key_base || app.try(:secrets).try(:secret_key_base)
       end
 
       if app.config.active_elastic_job.process_jobs == true


### PR DESCRIPTION
- Added ruby 3.2/3.3 to matrix testing, along with Rails 7.1 + 7.2 (_think_ targets are correct)
- Used `try` to handle when `secrets` is not there 
- Updated checkout action

Want to test installing this on a project with Rails 7.2 to verify it launches in a fully rails env, hence draft status